### PR TITLE
feat(dav): add regex to match Gnome and KDE calendar user-agents

### DIFF
--- a/apps/dav/lib/CalDAV/WebcalCaching/Plugin.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Plugin.php
@@ -23,10 +23,14 @@ class Plugin extends ServerPlugin {
 	 * that do not support subscriptions on their own
 	 *
 	 * /^MSFT-WIN-3/ - Windows 10 Calendar
+     * /Evolution/ - Gnome Calendar/Evolution
+	 * /KIO/ - KDE PIM/Akonadi
 	 * @var string[]
 	 */
 	public const ENABLE_FOR_CLIENTS = [
-		"/^MSFT-WIN-3/"
+		"/^MSFT-WIN-3/",
+		"/Evolution/",
+		"/KIO/"
 	];
 
 	/**


### PR DESCRIPTION
* Resolves: #17754

## Summary
Original Pull Request by @msrn: https://github.com/nextcloud/server/pull/33729 which became stale.

Quote: "This pull requests adds Gnome Calendar/Evolution and KDE PIM/Akonadi calendars to the list of user-agents in WebCalCaching -plugin, and exposes subscribed calendars to these calendar clients."

User-agent of Gnome Calendar/Evolution
Evolution/3.40.3

KDE PIM/Akonadi user-agent
Mozilla/5.0 (X11; Linux x86_64) KIO/5.86 akonadi_davgroupware_resource_1/5.18.2 (21.08.2)

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
